### PR TITLE
feat: atuin/channels

### DIFF
--- a/files/dotfiles/.config/waybar/config
+++ b/files/dotfiles/.config/waybar/config
@@ -78,6 +78,7 @@
       "sway/mode"
     ],
     "modules-right": [
+      "tray",
       "bluetooth",
       "temperature",
       "cpu",


### PR DESCRIPTION
- Configure channels via `home-channels-service-type`.
- Add `Rosenthal` channel.
- Add and configure `atuin` to keep shell history.